### PR TITLE
Removes length function on simple variable

### DIFF
--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -81,7 +81,7 @@ module "asg" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count                    = "${length(var.load_balancer_count)}"
+  count                    = "${var.load_balancer_count}"
   security_group_id        = "${module.asg.security_group_id}"
   type                     = "ingress"
   protocol                 = "tcp"


### PR DESCRIPTION
It should be an mistake already fixed in https://github.com/TeliaSoneraNorge/divx-terraform-modules/pull/151