### PR TITLE
Fix confusion between the two AWS secret backends in Concourse.

### DIFF
--- a/concourse/atc/cloud-config.yml
+++ b/concourse/atc/cloud-config.yml
@@ -53,7 +53,6 @@ write_files:
 
       ${github_users}
       ${github_teams}
-      Environment="AWS_REGION=${region}"
       Environment="CONCOURSE_BASIC_AUTH_USERNAME=${basic_auth_username}"
       Environment="CONCOURSE_BASIC_AUTH_PASSWORD=${basic_auth_password}"
       Environment="CONCOURSE_GITHUB_AUTH_CLIENT_ID=${github_client_id}"
@@ -69,7 +68,7 @@ write_files:
       Environment="CONCOURSE_OLD_ENCRYPTION_KEY=${old_encryption_key}"
 
       ExecStartPre=/bin/bash -c "/bin/systemctl set-environment CONCOURSE_PEER_URL=http://$(curl -L http://169.254.169.254/latest/meta-data/local-ipv4):${atc_port}"
-      ExecStart=/usr/local/bin/concourse web
+      ExecStart=/usr/local/bin/concourse web --aws-ssm-region=${region}
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
`AWS_REGION` seems to be the environment variable for both the Secrets Manager and SSM backends in Concourse. From the logs it seems like Secrets Manager trumps SSM - as such, this PR tries to be more explicit about which secret backend we _want_ to use.