### PR TITLE
Add lifecycle lambda for graceful updates of ECS cluster (closes #36).

### DIFF
--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -90,3 +90,11 @@ resource "aws_security_group_rule" "ingress" {
   to_port                  = "65535"
   source_security_group_id = "${element(var.load_balancers, count.index)}"
 }
+
+module "lifecycle_lambda" {
+  source = "github.com/itsdalmo/tf_aws_ecs_instance_draining_on_scale_in?ref=2695835"
+
+  autoscaling_group_name = "${module.asg.id}"
+  hook_heartbeat_timeout = 1800
+  hook_default_result    = "ABANDON"
+}

--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "ingress" {
 }
 
 module "lifecycle_lambda" {
-  source = "github.com/itsdalmo/tf_aws_ecs_instance_draining_on_scale_in?ref=2695835"
+  source = "github.com/itsdalmo/tf_aws_ecs_instance_draining_on_scale_in?ref=7a333d3"
 
   autoscaling_group_name = "${module.asg.id}"
   hook_heartbeat_timeout = 1800

--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -92,7 +92,7 @@ resource "aws_security_group_rule" "ingress" {
 }
 
 module "lifecycle_lambda" {
-  source = "github.com/itsdalmo/tf_aws_ecs_instance_draining_on_scale_in?ref=7a333d3"
+  source = "github.com/itsdalmo/tf_aws_ecs_instance_draining_on_scale_in?ref=310d2e6"
 
   autoscaling_group_name = "${module.asg.id}"
   hook_heartbeat_timeout = 1800


### PR DESCRIPTION
Not much to it apparently. Note that this is blocked until we decide what to do with the module (i.e., we are not going to use the fork). For now we can use this fork to test that it works.