### PR TITLE
Add license_model variable

### DIFF
--- a/rds-instance-full/main.tf
+++ b/rds-instance-full/main.tf
@@ -87,6 +87,8 @@ module "rds" {
   tags = "${local.tags}"
 
   parameters = "${var.parameters}"
+
+  license_model = "${var.license_model}"
 }
 
 ######

--- a/rds-instance-full/variables.tf
+++ b/rds-instance-full/variables.tf
@@ -82,3 +82,8 @@ variable "parameters" {
   description = "List of parameters for RDS parameter group"
   default     = []
 }
+
+variable "license_model" {
+  description = "License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1"
+  default     = ""
+}


### PR DESCRIPTION
Input variable is needed for Oracle RDS instances, which are used in this [PR](https://github.com/TeliaSoneraNorge/devops/pull/325)