### PR TITLE
Add an password exception in case engine is oracle

### DIFF
--- a/rds-instance-full/main.tf
+++ b/rds-instance-full/main.tf
@@ -13,6 +13,7 @@ resource "random_string" "generated_db_password" {
   upper  = true
   lower  = true
   number = true
+  special = "${substr(var.engine, 0, 6)   == "oracle" ? false : true}"
 }
 
 locals {


### PR DESCRIPTION
If Oracle instance is used, password cannot be that random as it currently is. That's why I added an exception. This should be also considered before merge of this [PR](https://github.com/TeliaSoneraNorge/devops/pull/325)