### PR TITLE
WIP: Randomize the container placement strategy for concourse.

### DIFF
--- a/concourse/atc/cloud-config.yml
+++ b/concourse/atc/cloud-config.yml
@@ -66,6 +66,7 @@ write_files:
       Environment="CONCOURSE_SESSION_SIGNING_KEY=/concourse/keys/web/session_signing_key"
       Environment="CONCOURSE_ENCRYPTION_KEY=${encryption_key}"
       Environment="CONCOURSE_OLD_ENCRYPTION_KEY=${old_encryption_key}"
+      Environment="CONCOURSE_CONTAINER_PLACEMENT_STRATEGY=random"
 
       ExecStartPre=/bin/bash -c "/bin/systemctl set-environment CONCOURSE_PEER_URL=http://$(curl -L http://169.254.169.254/latest/meta-data/local-ipv4):${atc_port}"
       ExecStart=/usr/local/bin/concourse web --aws-ssm-region=${region}


### PR DESCRIPTION
This closes https://github.com/TeliaSoneraNorge/divx-terraform-modules/issues/104 (issue from old repository). However, it needs some discussion:

Randomising the container placement will help us have a more equally distributed CPU load (or so I've been led to believe). However, it also means that our builds will be less likely to be scheduled on the same worker twice and able to reuse a cache.

For Java builds, the lack of a consistent cache would probably be a problem - so it's a bit of a tradeoff. If we don't randomise container placement, then we will (continue to) have a bit uneven CPU loads on our workers. This can make some builds run a bit slowly if two big jobs that have their volumes placed on the same instance, and they both trigger at the same time, since today they would be scheduled to run on the same instance. 

