### PR TITLE
Added prefix for Key alias in init module

### DIFF
--- a/terraform/init/init.tf
+++ b/terraform/init/init.tf
@@ -63,7 +63,7 @@ resource "aws_kms_key" "encrypt" {
 }
 
 resource "aws_kms_alias" "encrypt-alias" {
-  name          = "alias/terraform-state-encryption-key"
+  name          = "${var.prefix}-alias/terraform-state-encryption-key"
   target_key_id = "${aws_kms_key.encrypt.key_id}"
 }
 

--- a/terraform/init/init.tf
+++ b/terraform/init/init.tf
@@ -63,7 +63,7 @@ resource "aws_kms_key" "encrypt" {
 }
 
 resource "aws_kms_alias" "encrypt-alias" {
-  name          = "${var.prefix}-alias/terraform-state-encryption-key"
+  name          = "alias/${var.prefix}-terraform-state-encryption-key"
   target_key_id = "${aws_kms_key.encrypt.key_id}"
 }
 


### PR DESCRIPTION
I needed to run the init twice against the same account, because I managed to pick a non- unique bucket name.
When I re-ran the init script with a new prefix, it fails because the key alias name does not have the prefix in 
it's name, and it would create a duplicate. 

Probably corner case, but the prefix does not hurt :)