### PR TITLE
Fix for task execution- and task roles.

### DIFF
--- a/ecs/fargate/main.tf
+++ b/ecs/fargate/main.tf
@@ -13,20 +13,6 @@ resource "aws_cloudwatch_log_group" "main" {
 }
 
 # ------------------------------------------------------------------------------
-# IAM - Service role- is this used?
-# ------------------------------------------------------------------------------
-resource "aws_iam_role" "service" {
-  name               = "${var.prefix}-service-role"
-  assume_role_policy = "${data.aws_iam_policy_document.service_assume.json}"
-}
-
-resource "aws_iam_role_policy" "service_permissions" {
-  name   = "${var.prefix}-service-permissions"
-  role   = "${aws_iam_role.service.id}"
-  policy = "${data.aws_iam_policy_document.service_permissions.json}"
-}
-
-# ------------------------------------------------------------------------------
 # IAM - Task execution role, needed to pull ECR images etc.
 # ------------------------------------------------------------------------------
 resource "aws_iam_role" "execution" {

--- a/ecs/fargate/main.tf
+++ b/ecs/fargate/main.tf
@@ -37,25 +37,7 @@ resource "aws_iam_role" "execution" {
 resource "aws_iam_role_policy" "task_execution" {
   name   = "${var.prefix}-task-execution"
   role   = "${aws_iam_role.execution.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-     {
-      "Effect": "Allow",
-      "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+  policy = "${data.aws_iam_policy_document.task_execution_permissions.json}"
 }
 
 # ------------------------------------------------------------------------------
@@ -141,6 +123,7 @@ resource "aws_ecs_task_definition" "task" {
   cpu                      = "${var.task_definition_cpu}"
   memory                   = "${var.task_definition_ram}"
   task_role_arn            = "${aws_iam_role.task.arn}"
+
   container_definitions = <<EOF
 [{
     "cpu":0,

--- a/ecs/fargate/main.tf
+++ b/ecs/fargate/main.tf
@@ -137,7 +137,7 @@ EOF
 }
 
 resource "aws_ecs_service" "service" {
-  depends_on                         = ["aws_iam_role_policy.service_permissions", "null_resource.lb_exists"]
+  depends_on                         = ["null_resource.lb_exists"]
   name                               = "${var.prefix}"
   cluster                            = "${var.cluster_id}"
   task_definition                    = "${aws_ecs_task_definition.task.arn}"

--- a/ecs/fargate/outputs.tf
+++ b/ecs/fargate/outputs.tf
@@ -9,14 +9,6 @@ output "target_group_arn" {
   value = "${aws_lb_target_group.task.arn}"
 }
 
-output "service_role_arn" {
-  value = "${aws_iam_role.service.arn}"
-}
-
-output "service_role_name" {
-  value = "${aws_iam_role.service.name}"
-}
-
 output "task_role_arn" {
   value = "${aws_iam_role.task.arn}"
 }

--- a/ecs/fargate/policies.tf
+++ b/ecs/fargate/policies.tf
@@ -59,3 +59,23 @@ data "aws_iam_policy_document" "task_permissions" {
     ]
   }
 }
+
+# Task logging privileges
+data "aws_iam_policy_document" "task_execution_permissions" {
+  statement {
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+  }
+}

--- a/ecs/fargate/policies.tf
+++ b/ecs/fargate/policies.tf
@@ -1,36 +1,3 @@
-# ECS service assume policy
-data "aws_iam_policy_document" "service_assume" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ecs.amazonaws.com"]
-    }
-  }
-}
-
-# ECS service permissions
-data "aws_iam_policy_document" "service_permissions" {
-  # NOTE: ALB does not support resource level permissions :/
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "elasticloadbalancing:Describe*",
-      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-      "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-      "elasticloadbalancing:DeregisterTargets",
-      "elasticloadbalancing:RegisterTargets",
-    ]
-
-    resources = [
-      "*",
-    ]
-  }
-}
-
 # Task role assume policy
 data "aws_iam_policy_document" "task_assume" {
   statement {


### PR DESCRIPTION
* Task role was omitted from the service, causing applications using SDK's or APIs within containers to be unable to get credentials 
* service execution role (needed by ECS) and Task role (needed by application)  is now clearly separated 
* It seems that Service role is not used, I think we can remove it as well. See comments in terraform file main.tf
