### PR TITLE
Fix ECS memory reservation.

### DIFF
--- a/ecs/service/main.tf
+++ b/ecs/service/main.tf
@@ -67,13 +67,16 @@ data "null_data_source" "task_environment" {
 resource "aws_ecs_task_definition" "main" {
   family        = "${var.prefix}"
   task_role_arn = "${aws_iam_role.task.arn}"
+  cpu           = "${var.task_definition_cpu}"
+  memory        = "${var.task_definition_ram}"
 
+  # Source: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
   container_definitions = <<EOF
 [{
     "name": "${var.prefix}",
     "image": "${var.task_definition_image}",
     "cpu": ${var.task_definition_cpu},
-    "memory": ${var.task_definition_ram},
+    "memoryReservation": ${var.task_definition_ram},
     "essential": true,
     "portMappings": [{
       "HostPort": 0,


### PR DESCRIPTION
While moving a copy of the ECS modules to a new repository, I discovered that the container definitions used for `ecs/service` specifies `memory` rather than `memoryReservation`. I believe this to have been a mistake from mixing up the documentation for a task definition and a container definition (which is a part of task definitions):

- See task definition docs [here](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html) and [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html).
- See container definition docs [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html).

Currently, the `task_definition_ram` sets `memory` in the container definition, which imposes a hard limit on the amount of memory that can be consumed by a running container, if the limit is exceeded it will be killed. I think this is not the intended behaviour for any users of this module, and this PR aims to fix that.

Having read the documentation, I believe what we want is the following:
- `memoryReservation` specified in the container definition, so that we reserve some memory but allow the container to exceed the reservation.
- `memory` and `cpu` specified in the task definition. The documentation does not give a lot of details about what this actually does (outside fargate), but I presume it is used by ECS to work out container placement in the cluster?

By not specifying `memory` on the container definition, we run the risk of having leaky applications eat up all the memory. Personally I think its better to deal with the underlying problem (fix the memory leak), than have a hard limit on memory which restarts the application whenever it reaches the hard limit. Not sure if there are any other uses for this parameter?

PS: This should be tested before it is merged, and I was hoping that perhaps @neugeeug could test it on the NEO dev/staging environment?