### PR TITLE
IPv6 Support for VPCs

### DIFF
--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -134,7 +134,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0","::/0"]
 }
 
 resource "aws_launch_configuration" "main" {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -134,7 +134,8 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0", "::/0"]
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
 }
 
 resource "aws_launch_configuration" "main" {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -134,7 +134,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0","::/0"]
+  cidr_blocks       = ["0.0.0.0/0", "::/0"]
 }
 
 resource "aws_launch_configuration" "main" {

--- a/ec2/spot-request/main.tf
+++ b/ec2/spot-request/main.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0","::/0"]
+  cidr_blocks       = ["0.0.0.0/0", "::/0"]
 }
 
 resource "aws_iam_instance_profile" "ec2" {

--- a/ec2/spot-request/main.tf
+++ b/ec2/spot-request/main.tf
@@ -56,7 +56,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0","::/0"]
 }
 
 resource "aws_iam_instance_profile" "ec2" {

--- a/ec2/spot-request/main.tf
+++ b/ec2/spot-request/main.tf
@@ -56,7 +56,8 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "-1"
   from_port         = 0
   to_port           = 0
-  cidr_blocks       = ["0.0.0.0/0", "::/0"]
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
 }
 
 resource "aws_iam_instance_profile" "ec2" {

--- a/ec2/vpc/README.md
+++ b/ec2/vpc/README.md
@@ -4,7 +4,8 @@ This is a module which simplifies setting up a new VPC and getting it into a use
 
 - Creates one public subnet per availability zone (with a shared route table and internet gateway).
 - Creates the desired number of private subnets (with one NAT gateway and route table per subnet).
-- Evenly splits the specified CIDR block between public/private subnets.
+- Creates an egress only internet gateway for IPv6 traffic outbound from the private subnets
+- Evenly splits the specified IPv4 CIDR block between public/private subnets.
 
-Note that each private subnet has a route table which targets an individual NAT gateway when accessing
-the internet, which means that instances in a given private subnet will have a static IP.
+Note that, if create_nat_gateways is enabled, each private subnet has a route table which targets an individual NAT gateway when accessing
+the internet over IPv4, which means that all instances in a given private subnet will appear to have the same static IP from the outside.

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -69,10 +69,11 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
-  depends_on             = ["aws_internet_gateway.public", "aws_route_table.public"]
-  route_table_id         = "${aws_route_table.public.id}"
-  gateway_id             = "${aws_internet_gateway.public.id}"
-  destination_cidr_block = "0.0.0.0/0"
+  depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
+  route_table_id              = "${aws_route_table.public.id}"
+  gateway_id                  = "${aws_internet_gateway.public.id}"
+  destination_cidr_block      = "0.0.0.0/0"
+  destination_ipv6_cidr_block = "::/0"
 }
 
 resource "aws_route" "ip6-public" {

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -15,9 +15,9 @@ variable "private_subnets" {
   default     = "0"
 }
 
-variable "use-egress-only-igw"{
+variable "use-egress-only-igw" {
   description = "Optional:  If this is set to true private subnets will route trafffic to the internet via an egress only gateway (only works for ipv6)"
-  default = "false"
+  default     = "false"
 }
 
 variable "dns_hostnames" {
@@ -142,14 +142,14 @@ resource "aws_route" "ip6-private" {
 }
 
 resource "aws_subnet" "private" {
-  count                   = "${local.private_count}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, local.az_count + count.index)}"
-  availability_zone       = "${element(data.aws_availability_zones.main.names, count.index)}"
-  map_public_ip_on_launch = "false"
-  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"
+  count                           = "${local.private_count}"
+  vpc_id                          = "${aws_vpc.main.id}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, local.az_count + count.index)}"
+  availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
+  map_public_ip_on_launch         = "false"
+  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"
   assign_ipv6_address_on_creation = "true"
-  tags                    = "${merge(var.tags, map("Name", "${var.prefix}-private-subnet-${count.index + 1}"))}"
+  tags                            = "${merge(var.tags, map("Name", "${var.prefix}-private-subnet-${count.index + 1}"))}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -119,7 +119,7 @@ resource "aws_route_table" "private" {
 
 resource "aws_route" "private" {
   depends_on             = ["aws_nat_gateway.private", "aws_route_table.private"]
-  count                  = "${local.private_count}"
+  count                  = "${local.nat_gateway_count}"
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   nat_gateway_id         = "${element(aws_nat_gateway.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -75,6 +75,13 @@ resource "aws_route" "public" {
   destination_cidr_block = "0.0.0.0/0"
 }
 
+resource "aws_route" "ip6-public" {
+  depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
+  route_table_id         = "${aws_route_table.public.id}"
+  gateway_id             = "${aws_internet_gateway.public.id}"
+  destination_ipv6_cidr_block = "::/0"
+}
+
 resource "aws_subnet" "public" {
   count                   = "${local.az_count}"
   vpc_id                  = "${aws_vpc.main.id}"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -39,7 +39,7 @@ data "aws_availability_zones" "main" {}
 locals {
   az_count          = "${length(data.aws_availability_zones.main.names)}"
   private_count     = "${min(length(data.aws_availability_zones.main.names), var.private_subnets)}"
-  nat_gateway_count = "${var.create_nat_gateways == "true"? min(length(data.aws_availability_zones.main.names),var.private_subnets):0 }"
+  nat_gateway_count = "${var.create_nat_gateways == "true"? min(length(data.aws_availability_zones.main.names),var.private_subnets) : 0 }"
 }
 
 # NOTE: depends_on is added for the vpc because terraform sometimes
@@ -133,7 +133,7 @@ resource "aws_route" "private" {
   destination_cidr_block = "0.0.0.0/0"
 }
 
-resource "aws_route" "ip6-private" {
+resource "aws_route" "ipv6-private" {
   depends_on                  = ["aws_egress_only_internet_gateway.outbound", "aws_route_table.private"]
   count                       = "${local.private_count}"
   route_table_id              = "${element(aws_route_table.private.*.id, count.index)}"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -69,10 +69,16 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
+  depends_on             = ["aws_internet_gateway.public", "aws_route_table.public"]
+  route_table_id         = "${aws_route_table.public.id}"
+  gateway_id             = "${aws_internet_gateway.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+}
+
+resource "aws_route" "ip6-public" {
   depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
   route_table_id              = "${aws_route_table.public.id}"
   gateway_id                  = "${aws_internet_gateway.public.id}"
-  destination_cidr_block      = "0.0.0.0/0"
   destination_ipv6_cidr_block = "::/0"
 }
 

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -85,7 +85,7 @@ resource "aws_route" "ipv6-public" {
 resource "aws_subnet" "public" {
   count                           = "${local.az_count}"
   vpc_id                          = "${aws_vpc.main.id}"
-  cidr_block                      = "${cidrsubnet(var.cidr_block, 3, count.index)}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, 4, count.index)}"
   availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch         = "true"
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)}"
@@ -144,7 +144,7 @@ resource "aws_route" "ipv6-private" {
 resource "aws_subnet" "private" {
   count                           = "${local.private_count}"
   vpc_id                          = "${aws_vpc.main.id}"
-  cidr_block                      = "${cidrsubnet(var.cidr_block, 3, local.az_count + count.index)}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, 4, local.az_count + count.index)}"
   availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch         = "false"
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -81,7 +81,7 @@ resource "aws_subnet" "public" {
   cidr_block              = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, count.index)}"
   availability_zone       = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch = "true"
-  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, local.az_count + local.private_count, count.index)}"
+  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)}"
   assign_ipv6_address_on_creation = true
 
   tags = "${merge(var.tags, map("Name", "${var.prefix}-public-subnet-${count.index + 1}"))}"
@@ -140,7 +140,7 @@ resource "aws_subnet" "private" {
   cidr_block              = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, local.az_count + count.index)}"
   availability_zone       = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch = "false"
-  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, local.az_count + local.private_count, local.az_count + count.index)}"
+  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"
   tags = "${merge(var.tags, map("Name", "${var.prefix}-private-subnet-${count.index + 1}"))}"
 }
 

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -76,13 +76,6 @@ resource "aws_route" "public" {
   destination_ipv6_cidr_block = "::/0"
 }
 
-resource "aws_route" "ip6-public" {
-  depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
-  route_table_id              = "${aws_route_table.public.id}"
-  gateway_id                  = "${aws_internet_gateway.public.id}"
-  destination_ipv6_cidr_block = "::/0"
-}
-
 resource "aws_subnet" "public" {
   count                           = "${local.az_count}"
   vpc_id                          = "${aws_vpc.main.id}"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -51,7 +51,7 @@ resource "aws_vpc" "main" {
   enable_dns_support               = "true"
   enable_dns_hostnames             = "${var.dns_hostnames}"
   assign_generated_ipv6_cidr_block = true
-  tags = "${merge(var.tags, map("Name", "${var.prefix}-vpc"))}"
+  tags                             = "${merge(var.tags, map("Name", "${var.prefix}-vpc"))}"
 }
 
 resource "aws_internet_gateway" "public" {
@@ -77,19 +77,19 @@ resource "aws_route" "public" {
 
 resource "aws_route" "ip6-public" {
   depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
-  route_table_id         = "${aws_route_table.public.id}"
-  gateway_id             = "${aws_internet_gateway.public.id}"
+  route_table_id              = "${aws_route_table.public.id}"
+  gateway_id                  = "${aws_internet_gateway.public.id}"
   destination_ipv6_cidr_block = "::/0"
 }
 
 resource "aws_subnet" "public" {
-  count                   = "${local.az_count}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, count.index)}"
-  availability_zone       = "${element(data.aws_availability_zones.main.names, count.index)}"
-  map_public_ip_on_launch = "true"
-  ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)}"
-  assign_ipv6_address_on_creation = true
+  count                           = "${local.az_count}"
+  vpc_id                          = "${aws_vpc.main.id}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, count.index)}"
+  availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
+  map_public_ip_on_launch         = "true"
+  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)}"
+  assign_ipv6_address_on_creation = "true"
 
   tags = "${merge(var.tags, map("Name", "${var.prefix}-public-subnet-${count.index + 1}"))}"
 }
@@ -148,7 +148,7 @@ resource "aws_subnet" "private" {
   availability_zone       = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch = "false"
   ipv6_cidr_block         = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"
-  tags = "${merge(var.tags, map("Name", "${var.prefix}-private-subnet-${count.index + 1}"))}"
+  tags                    = "${merge(var.tags, map("Name", "${var.prefix}-private-subnet-${count.index + 1}"))}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -75,7 +75,7 @@ resource "aws_route" "public" {
   destination_cidr_block = "0.0.0.0/0"
 }
 
-resource "aws_route" "ip6-public" {
+resource "aws_route" "ipv6-public" {
   depends_on                  = ["aws_internet_gateway.public", "aws_route_table.public"]
   route_table_id              = "${aws_route_table.public.id}"
   gateway_id                  = "${aws_internet_gateway.public.id}"

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -15,9 +15,9 @@ variable "private_subnets" {
   default     = "0"
 }
 
-variable "use-egress-only-igw" {
-  description = "Optional:  If this is set to true private subnets will route trafffic to the internet via an egress only gateway (only works for ipv6)"
-  default     = "false"
+variable "create_nat_gateways" {
+  description = "Optional:  If this is set to false NAT gateways (which cost $) will not be created and the private subnets will only route trafffic to the internet via the egress only gateway(no cost) - Egress only gateways only works for IPv6)"
+  default     = "true"
 }
 
 variable "dns_hostnames" {
@@ -39,7 +39,7 @@ data "aws_availability_zones" "main" {}
 locals {
   az_count          = "${length(data.aws_availability_zones.main.names)}"
   private_count     = "${min(length(data.aws_availability_zones.main.names), var.private_subnets)}"
-  nat_gateway_count = "${var.use-egress-only-igw == "true"? 0 : min(length(data.aws_availability_zones.main.names),var.private_subnets)}"
+  nat_gateway_count = "${var.create_nat_gateways == "true"? min(length(data.aws_availability_zones.main.names),var.private_subnets):0 }"
 }
 
 # NOTE: depends_on is added for the vpc because terraform sometimes

--- a/ec2/vpc/vpc.tf
+++ b/ec2/vpc/vpc.tf
@@ -85,7 +85,7 @@ resource "aws_route" "ipv6-public" {
 resource "aws_subnet" "public" {
   count                           = "${local.az_count}"
   vpc_id                          = "${aws_vpc.main.id}"
-  cidr_block                      = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, count.index)}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, 3, count.index)}"
   availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch         = "true"
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)}"
@@ -144,7 +144,7 @@ resource "aws_route" "ipv6-private" {
 resource "aws_subnet" "private" {
   count                           = "${local.private_count}"
   vpc_id                          = "${aws_vpc.main.id}"
-  cidr_block                      = "${cidrsubnet(var.cidr_block, local.az_count + local.private_count, local.az_count + count.index)}"
+  cidr_block                      = "${cidrsubnet(var.cidr_block, 3, local.az_count + count.index)}"
   availability_zone               = "${element(data.aws_availability_zones.main.names, count.index)}"
   map_public_ip_on_launch         = "false"
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, local.az_count + count.index)}"


### PR DESCRIPTION
Includes option to turn off NAT gateway creation and use IPv6 egress only from private subnets 