### PR TITLE
Docker volume size

### DIFF
--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -159,7 +159,7 @@ resource "aws_launch_configuration" "main" {
     delete_on_termination = true
   }
   
-  block_device {
+  ebs_block_device {
     device_name = "/dev/xvdcz"
     volume_type = "gp2"
     volume_size = "${var.docker_storage}"

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -44,9 +44,10 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
-variable "docker_storage" {
-  description = "Size of volume dedicated for docker."
-  default     = "0"
+variable "additional_ebs_storage" {
+  description = "Additional EBS volume map with EBS configuration."
+  type        = "map"
+  default     = {}
 }
 
 variable "instance_count" {
@@ -159,10 +160,10 @@ resource "aws_launch_configuration" "main" {
   }
 
   ebs_block_device {
-    device_name           = "/dev/xvdcz"
-    volume_type           = "gp2"
-    volume_size           = "${var.docker_storage}"
-    delete_on_termination = true
+     volume_type           = "${lookup(var.additional_ebs_storage, "volume_type", "")}"
+     volume_size           = "${lookup(var.additional_ebs_storage, "volume_size", 0)}"
+     delete_on_termination = "${lookup(var.additional_ebs_storage, "delete_on_termination", "")}"  
+     device_name           = "${lookup(var.additional_ebs_storage, "device_name", "")}"
   }
 
   lifecycle {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -44,6 +44,12 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
+variable "docker_storage" {
+  description = "Size of volume dedicated for docker."
+  default     = "120"
+}
+
+
 variable "instance_count" {
   description = "Desired (and minimum) number of instances."
   default     = "1"
@@ -151,6 +157,12 @@ resource "aws_launch_configuration" "main" {
     volume_type           = "gp2"
     volume_size           = "${var.instance_volume_size}"
     delete_on_termination = true
+  }
+  
+  block_device {
+    device_name = "/dev/xvdcz"
+    volume_type = "gp2"
+    volume_size = "${var.docker_storage}"
   }
 
   lifecycle {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -46,7 +46,7 @@ variable "instance_volume_size" {
 
 variable "docker_storage" {
   description = "Size of volume dedicated for docker."
-  default     = "120"
+  default     = "0"
 }
 
 
@@ -160,6 +160,7 @@ resource "aws_launch_configuration" "main" {
   }
   
   ebs_block_device {
+    count       = "${var.docker_storage != 0 ? 1 : 0}"
     device_name = "/dev/xvdcz"
     volume_type = "gp2"
     volume_size = "${var.docker_storage}"

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -160,7 +160,6 @@ resource "aws_launch_configuration" "main" {
   }
   
   ebs_block_device {
-    count       = "${var.docker_storage != 0 ? 1 : 0}"
     device_name = "/dev/xvdcz"
     volume_type = "gp2"
     volume_size = "${var.docker_storage}"

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -89,6 +89,12 @@ variable "instance_policy" {
 EOF
 }
 
+variable "ebs_block_devices" {
+  description = "Additional EBS block devices to attach to the instance."
+  type        = "list"
+  default     = []
+}
+
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
   type        = "map"
@@ -159,12 +165,7 @@ resource "aws_launch_configuration" "main" {
     delete_on_termination = true
   }
 
-  ebs_block_device {
-     volume_type           = "${lookup(var.additional_ebs_storage, "volume_type", "")}"
-     volume_size           = "${lookup(var.additional_ebs_storage, "volume_size", 0)}"
-     delete_on_termination = "${lookup(var.additional_ebs_storage, "delete_on_termination", "")}"  
-     device_name           = "${lookup(var.additional_ebs_storage, "device_name", "")}"
-  }
+  ebs_block_device = ["${var.ebs_block_devices}"]
 
   lifecycle {
     create_before_destroy = true

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -49,7 +49,6 @@ variable "docker_storage" {
   default     = "0"
 }
 
-
 variable "instance_count" {
   description = "Desired (and minimum) number of instances."
   default     = "1"
@@ -158,11 +157,12 @@ resource "aws_launch_configuration" "main" {
     volume_size           = "${var.instance_volume_size}"
     delete_on_termination = true
   }
-  
+
   ebs_block_device {
-    device_name = "/dev/xvdcz"
-    volume_type = "gp2"
-    volume_size = "${var.docker_storage}"
+    device_name           = "/dev/xvdcz"
+    volume_type           = "gp2"
+    volume_size           = "${var.docker_storage}"
+    delete_on_termination = true
   }
 
   lifecycle {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -44,12 +44,6 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
-variable "additional_ebs_storage" {
-  description = "Additional EBS volume map with EBS configuration."
-  type        = "map"
-  default     = {}
-}
-
 variable "instance_count" {
   description = "Desired (and minimum) number of instances."
   default     = "1"

--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -87,7 +87,7 @@ module "asg" {
   instance_key         = "${var.instance_key}"
   instance_volume_size = "${var.instance_volume_size}"
   tags                 = "${var.tags}"
-  docker_storage       = "${var.docker_storage}"
+  additional_ebs_storage       = "${var.additional_ebs_storage}"
 }
 
 resource "aws_security_group_rule" "ingress" {

--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -87,6 +87,7 @@ module "asg" {
   instance_key         = "${var.instance_key}"
   instance_volume_size = "${var.instance_volume_size}"
   tags                 = "${var.tags}"
+  docker_storage       = "${var.docker_storage}"
 }
 
 resource "aws_security_group_rule" "ingress" {

--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -87,7 +87,13 @@ module "asg" {
   instance_key         = "${var.instance_key}"
   instance_volume_size = "${var.instance_volume_size}"
   tags                 = "${var.tags}"
-  additional_ebs_storage       = "${var.additional_ebs_storage}"
+
+  ebs_block_devices = [{
+    device_name           = "/dev/xvdcz"
+    volume_type           = "gp2"
+    volume_size           = "${var.docker_volume_size}"
+    delete_on_termination = true
+  }]
 }
 
 resource "aws_security_group_rule" "ingress" {

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -44,9 +44,10 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
-variable "docker_storage" {
-  description = "Size of volume dedicated for docker."
-  default     = "22"
+variable "additional_ebs_storage" {
+  description = "Additional EBS volume map with EBS configuration."
+  type        = "map"
+  default     = {}
 }
 
 variable "ecs_log_level" {

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -44,6 +44,11 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
+variable "docker_storage" {
+  description = "Size of volume dedicated for docker."
+  default     = "120"
+}
+
 variable "ecs_log_level" {
   description = "Log level for the ECS agent."
   default     = "info"

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -46,7 +46,7 @@ variable "instance_volume_size" {
 
 variable "docker_storage" {
   description = "Size of volume dedicated for docker."
-  default     = "120"
+  default     = "22"
 }
 
 variable "ecs_log_level" {

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -44,10 +44,9 @@ variable "instance_volume_size" {
   default     = "8"
 }
 
-variable "additional_ebs_storage" {
-  description = "Additional EBS volume map with EBS configuration."
-  type        = "map"
-  default     = {}
+variable "docker_volume_size" {
+  description = "Additional EBS volume size for docker service."
+  default     = 22
 }
 
 variable "ecs_log_level" {


### PR DESCRIPTION
Default size of ECS docker volume is 22GB, that is not that much. `docker_storage` is used in instance to set up the EBS volume to store docker related things. If `docker_storage` is set to zero, nothing should be created.

Default for the cluster instance was estimated to 22 GB. The `docker_storage` can be referenced elsewhere and used to enlarge the volume.